### PR TITLE
Flow Flex Card Support for Single Record and Record Collection Outputs

### DIFF
--- a/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flexcardFlow/fsc_flexcardFlow.js-meta.xml
+++ b/flow_screen_components/FlowScreenComponentsBasePack/force-app/main/default/lwc/fsc_flexcardFlow/fsc_flexcardFlow.js-meta.xml
@@ -42,6 +42,10 @@
             <property name="cb_allowMultiSelect" type="String" role="inputOnly" />
             <property name="selectedRecordIds" label="Selected Record Ids" type="String[]"
                 role="outputOnly" description="String Collection of selected Record ID's" />
+            <property name="selectedRecords" label="Selected Records" type="{T[]}"
+                role="outputOnly" description="Collection of complete selected record objects" />
+            <property name="selectedRecord" label="Selected Record" type="{T}" role="outputOnly"
+                description="Selected record variable" />
             <property name="objectAPIName" label="Object API Name" type="String" role="inputOnly"
                 default="Account" required="true"
                 description="The SObject API Name used to query fields and values must be the same object selected in Flexcard Object API Name" />


### PR DESCRIPTION
Flow Flex Cards will now support outputting the selected card as a single record variable or multiple cards as and record collection. 